### PR TITLE
Add planeHost configuration and update API base URL to support custom Plane host

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -15,6 +15,9 @@ startCommand:
       planeWorkspaceSlug:
         type: string
         description: Your Plane.so workspace slug identifier.
+      planeHost:
+        type: string
+        description: Yout Plane.so custom host.
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -24,8 +27,10 @@ startCommand:
       env: {
         PLANE_API_KEY: config.planeApiKey,
         PLANE_WORKSPACE_SLUG: config.planeWorkspaceSlug
+        PLANE_HOST: config.planeHost
       }
     })
   exampleConfig:
     planeApiKey: example_plane_api_key_12345
     planeWorkspaceSlug: example_workspace_slug
+    planeHost: https://your-plane.com

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ dotenv.config();
 // Retrieve the Plane API key from environment variables
 const PLANE_API_KEY = process.env.PLANE_API_KEY;
 const PLANE_WORKSPACE_SLUG = process.env.PLANE_WORKSPACE_SLUG;
+const PLANE_HOST = process.env.PLANE_HOST || "https://api.plane.so";
 
 if (!PLANE_API_KEY) {
   console.error("Error: PLANE_API_KEY environment variable is required");
@@ -199,7 +200,7 @@ async function callPlaneAPI(
   method: string,
   body?: any
 ): Promise<any> {
-  const baseUrl = `https://api.plane.so/api/v1/workspaces/${PLANE_WORKSPACE_SLUG}`;
+  const baseUrl = `${PLANE_HOST}/api/v1/workspaces/${PLANE_WORKSPACE_SLUG}`;
   const url = `${baseUrl}${endpoint}`;
 
   const options: RequestInit = {


### PR DESCRIPTION
## Summary

This pull request introduces a new environment variable, `PLANE_HOST`, to the MCP server.

### Changes
- Adds support for customizing the Plane API host endpoint via the `PLANE_HOST` environment variable.
- Updates the configuration schema and command function in `smithery.yaml` to include the new variable.
- Improves flexibility for deployments targeting custom Plane instances or self-hosted environments.

### Motivation
By allowing the Plane host to be configurable, users can easily switch between the default Plane API and their own custom or self-hosted Plane deployments.

---

**Files updated:**
- `src/index.ts`
- `smithery.yaml`