### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ A Model Context Protocol (MCP) server that enables LLMs to interact with [Plane.
 - Get detailed information about specific issues
 - Update existing issues with new information
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kelvin6365-plane-mcp-server).
+
 ## Prerequisites
 
 - Node.js 22.x or higher


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kelvin6365-plane-mcp-server).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new hosted deployment section documenting the availability of a fully hosted and managed version of the MCP server through Fronteir AI, providing users with an easy alternative to setting up and managing their own local installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->